### PR TITLE
Group associations for each person/publication record #77

### DIFF
--- a/content/people/ahmed-elshabasi.yaml
+++ b/content/people/ahmed-elshabasi.yaml
@@ -1,3 +1,6 @@
 name: Ahmed Elshabasi
 type: alumni
 past: master
+labs: 
+- utouch
+- data-experience

--- a/content/people/akashdeep-singh.yaml
+++ b/content/people/akashdeep-singh.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: undergrad
 email: akashdeep.singh4@ucalgary.ca
 linkedin: https://www.linkedin.com/in/akash02ita/
+labs: 
+- diff

--- a/content/people/anand-kumar.yaml
+++ b/content/people/anand-kumar.yaml
@@ -5,3 +5,5 @@ email: anand.kumar1@ucalgary.ca
 linkedin: https://www.linkedin.com/in/anand-kumar-rajpal/
 github: https://github.com/AnandKumarRajpal/
 scholar: https://scholar.google.com/citations?user=1_qfoBUAAAAJ&hl=en
+labs: 
+- diff

--- a/content/people/ashratuz-zavin-asha.yaml
+++ b/content/people/ashratuz-zavin-asha.yaml
@@ -2,3 +2,5 @@ name: Ashratuz Zavin Asha
 type: phd
 url: https://sites.google.com/view/ashratuzzavinasha
 scholar: https://scholar.google.com/citations?user=E7gtMMoAAAAJ
+labs: 
+- utouch

--- a/content/people/ben-pearman.yaml
+++ b/content/people/ben-pearman.yaml
@@ -1,2 +1,4 @@
 name: Ben Pearman
 type: master
+labs: 
+- data-experience

--- a/content/people/bon-adriel-aseniero.yaml
+++ b/content/people/bon-adriel-aseniero.yaml
@@ -7,3 +7,5 @@ scholar: https://scholar.google.com/citations?user=V4nRMoMAAAAJ
 twitter: https://twitter.com/HexenKoenig
 facebook: https://www.facebook.com/bonadriel
 linkedin: https://www.linkedin.com/in/bon-adriel-aseniero-47140560/
+labs: 
+- utouch

--- a/content/people/bonnie-wu.yaml
+++ b/content/people/bonnie-wu.yaml
@@ -1,2 +1,4 @@
 name: Bonnie Wu
 type: master
+labs: 
+- data-experience

--- a/content/people/carmen-hull.yaml
+++ b/content/people/carmen-hull.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: phd
 now: Northeastern University
 url: https://www.carmenhull.com/
+labs: 
+- data-experience

--- a/content/people/christopher-smith.yaml
+++ b/content/people/christopher-smith.yaml
@@ -2,3 +2,5 @@ name: Christopher Smith
 type: phd
 program: cs
 linkedin: https://www.linkedin.com/in/christopher-smith-uofc/
+labs: 
+- utouch

--- a/content/people/danissa-sandykbayeva.yaml
+++ b/content/people/danissa-sandykbayeva.yaml
@@ -3,3 +3,5 @@ type: master
 email: danissa.sandykbay1@ucalgary.ca
 scholar: https://scholar.google.com/citations?user=tWhlB7YAAAAJ
 linkedin: https://www.linkedin.com/in/danissa-sandykbayeva/
+labs: 
+- diff

--- a/content/people/darcy-norman.yaml
+++ b/content/people/darcy-norman.yaml
@@ -2,5 +2,7 @@ name: D'Arcy Norman
 type: alumni
 past: phd
 now: University of Calgary
+labs: 
+- utouch
 url: https://darcynorman.net/
 twitter: https://twitter.com/realdlnorman

--- a/content/people/desmond-larsen-rosner.yaml
+++ b/content/people/desmond-larsen-rosner.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: master
 github: https://github.com/desmondlr
 linkedin: https://www.linkedin.com/in/drplr/
+labs: 
+- utouch

--- a/content/people/godwin-saure.yaml
+++ b/content/people/godwin-saure.yaml
@@ -2,3 +2,5 @@ name: Godwin Saure
 type: undergrad
 email: godwin.saure@gmail.com
 linkedin: https://www.linkedin.com/in/godwin-saure/
+labs: 
+- data-experience

--- a/content/people/helen-ai-he.yaml
+++ b/content/people/helen-ai-he.yaml
@@ -7,3 +7,5 @@ url: https://helenaihe.com/research
 scholar: https://scholar.google.com/citations?user=FlMKf0gAAAAJ
 twitter: https://twitter.com/helenaihe
 email: helen.he1@ucalgary.ca
+labs: 
+- data-experience

--- a/content/people/huanjun-zhao.yaml
+++ b/content/people/huanjun-zhao.yaml
@@ -3,3 +3,5 @@ type: master
 url: https://contacts.ucalgary.ca/info/cpsc/profiles/1-12783408
 email: huanjun.zhao@ucalgary.ca
 linkedin: https://www.linkedin.com/in/huanjun-zhao-00b281230/
+labs: 
+- diff

--- a/content/people/iryna-luchak.yaml
+++ b/content/people/iryna-luchak.yaml
@@ -2,3 +2,5 @@ name: Iryna Luchak
 type: alumni
 past: master
 linkedin: https://www.linkedin.com/in/irynaluchak/
+labs: 
+- utouch

--- a/content/people/jagoda-walny.yaml
+++ b/content/people/jagoda-walny.yaml
@@ -5,3 +5,5 @@ now: Canada Energy Regulator (CER)
 url: https://www.fwd50.com/speaker/2395/jagoda-walny-nix
 scholar: https://scholar.google.ca/citations?user=EK99E-8AAAAJ&hl=en
 linkedin: https://www.linkedin.com/in/jagoda/?originalSubdomain=ca
+labs: 
+- data-experience

--- a/content/people/jessi-stark.yaml
+++ b/content/people/jessi-stark.yaml
@@ -5,3 +5,5 @@ now: University of Toronto
 url: https://jtstark.com/
 scholar: https://scholar.google.com/citations?user=aRkKN5UAAAAJ
 twitter: https://twitter.com/_jessistark
+labs: 
+- utouch

--- a/content/people/jiannan-li.yaml
+++ b/content/people/jiannan-li.yaml
@@ -4,3 +4,5 @@ past: master
 now: University of Toronto
 url: https://www.dgp.toronto.edu/~jiannanli/
 scholar: https://scholar.google.com/citations?user=wyW0rJQAAAAJ
+labs: 
+- utouch

--- a/content/people/karly-ross.yaml
+++ b/content/people/karly-ross.yaml
@@ -1,3 +1,5 @@
 name: Karly Ross
 type: master
+labs: 
+- data-experience
 linkedin: https://www.linkedin.com/in/karly-j-ross/

--- a/content/people/karthik-mahadevan.yaml
+++ b/content/people/karthik-mahadevan.yaml
@@ -4,3 +4,5 @@ past: master
 now: University of Toronto
 url: https://karthikm0.github.io/
 scholar: https://scholar.google.ca/citations?user=aK4siPkAAAAJ
+labs: 
+- utouch

--- a/content/people/kendra-wannamaker.yaml
+++ b/content/people/kendra-wannamaker.yaml
@@ -2,3 +2,5 @@ name: Kendra Wannamaker
 type: alumni
 past: master
 now: Autodesk Research
+labs: 
+- data-experience

--- a/content/people/kevin-van.yaml
+++ b/content/people/kevin-van.yaml
@@ -4,3 +4,5 @@ email: kevin.van@ucalgary.ca
 url: https://kevin-van.github.io/Website/
 github: https://github.com/kevin-van
 linkedin: https://www.linkedin.com/in/kevin-van-a66130204/
+labs: 
+- utouch

--- a/content/people/kurtis-danyluk.yaml
+++ b/content/people/kurtis-danyluk.yaml
@@ -1,3 +1,5 @@
 name: Kurtis Danyluk
 type: phd
 scholar: https://scholar.google.com/citations?user=vr-EF5IAAAAJ
+labs: 
+- data-experience

--- a/content/people/mackenzie-bowal.yaml
+++ b/content/people/mackenzie-bowal.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: undergrad
 email: mackenzie.bowal@ucalgary.ca
 linkedin: https://www.linkedin.com/in/mackenzie-bowal/
+labs: 
+- utouch

--- a/content/people/mackenzie-hisako-dalton.yaml
+++ b/content/people/mackenzie-hisako-dalton.yaml
@@ -2,3 +2,5 @@ name: Mackenzie Hisako Dalton
 type: alumni
 past: undergrad
 url: https://hisak00.weebly.com/
+labs: 
+- data-experience

--- a/content/people/martin-feick.yaml
+++ b/content/people/martin-feick.yaml
@@ -6,3 +6,5 @@ url: http://martinfeick.com/
 scholar: https://scholar.google.de/citations?user=az0GkfQAAAAJ
 github: https://github.com/MartinFk
 twitter: https://twitter.com/mafeick
+labs: 
+- utouch

--- a/content/people/nathalie-bressa.yaml
+++ b/content/people/nathalie-bressa.yaml
@@ -2,3 +2,5 @@ name: Nathalie Bressa
 type: alumni
 past: visiting
 now: Aarhus University
+labs: 
+- data-experience

--- a/content/people/nour-hammad.yaml
+++ b/content/people/nour-hammad.yaml
@@ -1,3 +1,5 @@
 name: Nour Hammad
 type: alumni
 past: undergrad
+labs: 
+- utouch

--- a/content/people/paige-sobrien.yaml
+++ b/content/people/paige-sobrien.yaml
@@ -1,3 +1,5 @@
 name: Paige So'Brien  
 type: alumni
 past: undergrad
+labs: 
+- data-experience

--- a/content/people/paul-lapides.yaml
+++ b/content/people/paul-lapides.yaml
@@ -2,3 +2,5 @@ name: Paul Lapides
 type: alumni
 past: phd
 url: http://www.paullapides.com/
+labs: 
+- utouch

--- a/content/people/paul-saulnier.yaml
+++ b/content/people/paul-saulnier.yaml
@@ -4,3 +4,5 @@ past: master
 now: Bravura Security
 url: http://paulsaulnier.com/
 linkedin: https://www.linkedin.com/in/paulsaulnier/
+labs: 
+- utouch

--- a/content/people/priya-dhawka.yaml
+++ b/content/people/priya-dhawka.yaml
@@ -4,3 +4,5 @@ past: master
 email: priyadarshinee.dhawk@ucalgary.ca
 github: https://github.com/dhawkap
 linkedin: https://www.linkedin.com/in/priya-d-15b743112/
+labs: 
+- data-experience

--- a/content/people/roberta-cabral-mota.yaml
+++ b/content/people/roberta-cabral-mota.yaml
@@ -1,3 +1,5 @@
 name: Roberta Cabral Mota
 type: phd
 url: https://www.robertacrmota.com/
+labs: 
+- utouch

--- a/content/people/sabrina-lakhdhir.yaml
+++ b/content/people/sabrina-lakhdhir.yaml
@@ -2,3 +2,5 @@ name: Sabrina Lakhdhir
 type: alumni
 past: undergrad
 now: University of Victoria
+labs: 
+- utouch

--- a/content/people/sasha-ivanov.yaml
+++ b/content/people/sasha-ivanov.yaml
@@ -2,3 +2,5 @@ name: Sasha Ivanov
 type: alumni
 past: master
 now: Meta Reality Labs
+labs: 
+- data-experience

--- a/content/people/setareh-manesh.yaml
+++ b/content/people/setareh-manesh.yaml
@@ -1,3 +1,5 @@
 name: Setareh Manesh
 type: alumni
 past: master
+labs: 
+- utouch

--- a/content/people/shamim-seyson.yaml
+++ b/content/people/shamim-seyson.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: undergrad
 email: shamim.seyson@ucalgary.ca
 linkedin: https://www.linkedin.com/in/shamimseyson/
+labs: 
+- data-experience

--- a/content/people/shanna-hollingworth.yaml
+++ b/content/people/shanna-hollingworth.yaml
@@ -3,3 +3,5 @@ type: master
 email: shanna.hollingwor1@ucalgary.ca
 url: https://shanna1408.github.io/
 linkedin: https://www.linkedin.com/in/shanna-hollingworth/
+labs: 
+- data-experience

--- a/content/people/shivesh-jadon.yaml
+++ b/content/people/shivesh-jadon.yaml
@@ -6,3 +6,5 @@ url: https://shivesh.dev/
 scholar: https://scholar.google.com/citations?user=EwqYU2sAAAAJ&hl=en
 linkedin: https://www.linkedin.com/in/shiveshjadon/
 twitter: https://twitter.com/ShiveshJadon
+labs: 
+- data-experience

--- a/content/people/simon-kluber.yaml
+++ b/content/people/simon-kluber.yaml
@@ -1,3 +1,5 @@
 name: Simon Klüber
 type: alumni
 past: visiting
+labs: 
+- data-experience

--- a/content/people/soren-knudsen.yaml
+++ b/content/people/soren-knudsen.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: postdoc
 now: University of Copenhagen
 url: http://sorenknudsen.com/
+labs: 
+- data-experience

--- a/content/people/sowmya-somanath.yaml
+++ b/content/people/sowmya-somanath.yaml
@@ -2,6 +2,8 @@ name: Sowmya Somanath
 type: alumni
 past: phd
 now: University of Victoria
+labs: 
+- utouch
 url: http://pages.cpsc.ucalgary.ca/~ssomanat/
 scholar: https://scholar.google.ca/citations?user=R9ar1NkAAAAJ
 twitter: https://twitter.com/sowmyasomanath

--- a/content/people/tian-xia.yaml
+++ b/content/people/tian-xia.yaml
@@ -3,3 +3,5 @@ type: alumni
 past: undergrad
 linkedin: https://www.linkedin.com/in/tianxiacs/
 email: tian.xia2@ucalgary.ca
+labs: 
+- utouch

--- a/content/people/tim-au-yeung.yaml
+++ b/content/people/tim-au-yeung.yaml
@@ -1,3 +1,5 @@
 name: Tim Au Yeung
 type: phd
 linkedin: https://www.linkedin.com/in/tim-au-yeung-3a29816
+labs: 
+- utouch

--- a/content/people/victoria-wong.yaml
+++ b/content/people/victoria-wong.yaml
@@ -1,2 +1,4 @@
 name: Victoria Wong
 type: undergrad
+labs: 
+- data-experience

--- a/content/people/wei-wei.yaml
+++ b/content/people/wei-wei.yaml
@@ -4,3 +4,6 @@ past: master
 url: http://www.weiweiff.com/
 email: wei.wei2@ucalgary.ca
 linkedin: https://www.linkedin.com/in/wei-wei-961a211ba/
+labs: 
+- utouch
+- data-experience

--- a/content/people/zachary-mckendrick.yaml
+++ b/content/people/zachary-mckendrick.yaml
@@ -4,3 +4,5 @@ past: phd
 now: University of Waterloo
 url: https://uwaterloo.ca/postdoctoral-scholars/blog/2024-provosts-program-interdisciplinary-postdoctoral-scholar-2
 linkedin: https://www.linkedin.com/in/zach-mckendrick-7a24bb3b
+labs: 
+- utouch


### PR DESCRIPTION
Closes: #77

content/people/*.yaml: add labs affiliations to DIFFLAB, Health Vis Futures, uTouch, Data Experience Lab